### PR TITLE
Bug 1033 setting eventDays

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-importexport ===
 Requires at least: 5.9
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -20,6 +20,9 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.6.1 =
+* Bug 1033 - only set eventDays if a numeric value provided in event import file
+* Tested up to WordPress 6.5
 = 1.6.0 =
 * First production code release
 * Tested up to WordPress 6.4

--- a/u3a-import.php
+++ b/u3a-import.php
@@ -322,7 +322,8 @@ function u3a_csv_import_events($force_new_events = false)
         if (isset($event['Time'])) {
             update_post_meta($postid, 'eventTime', sanitize_text_field($event['Time']));
         }
-        if (isset($event['Days'])) {
+        // Only set eventDays if a 'Days' value is provided
+        if (isset($event['Days']) && $event['Days'] > 0) {
             update_post_meta($postid, 'eventDays', (int) $event['Days']);
         }
         // Set eventEndDate

--- a/u3a-importexport.php
+++ b/u3a-importexport.php
@@ -2,7 +2,7 @@
 /** 
 Plugin Name: u3a SiteWorks Import Export
 Description: Provides facility to import and export CSV data files
-Version: 1.6.0
+Version: 1.6.1
 Author: u3a SiteWorks team
 Author URI: https://siteworks.u3a.org.uk/
 Plugin URI: https://siteworks.u3a.org.uk/
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('U3A_IMPORTEXPORT_VERSION', '1.6.0');
+define('U3A_IMPORTEXPORT_VERSION', '1.6.1');
 
 if (!is_admin()) return; // Plugin only relevant on admin pages.
 


### PR DESCRIPTION
The code was wrongly setting a value of 0 for eventDays when the Days column was present in the import file but no value provided for Days in a row.  Rather than setting 0, the eventDays field should not be set as it is an optional field.

Change also indicates tested with WP 6.5