### PR TITLE
OP1104 fatal error if plugin.php not loaded

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-importexport ===
 Requires at least: 5.9
-Tested up to: 6.5
+Tested up to: 6.7
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -20,6 +20,10 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.6.3 =
+* Bug 1104 Fix fatal error if plugin.php is not loaded when plugin initialises.
+* Tested up to WordPress 6.7
+* Add "Requires Plugins" header field to specify dependency on SiteWorks core plugin
 = 1.6.2 =
 * Import and export now handle core v1.1.0 metadata fields and multiple group categories
 * Feature 1032 - Alter group status short term from "Suspended" to "Dormant"

--- a/u3a-importexport.php
+++ b/u3a-importexport.php
@@ -2,23 +2,27 @@
 /** 
 Plugin Name: u3a SiteWorks Import Export
 Description: Provides facility to import and export CSV data files
-Version: 1.6.2
+Version: 1.6.3
 Author: u3a SiteWorks team
 Author URI: https://siteworks.u3a.org.uk/
 Plugin URI: https://siteworks.u3a.org.uk/
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Requires Plugins: u3a-siteworks-core
+
 */
 
 if (!defined('ABSPATH')) {
     exit;
 }
 
-define('U3A_IMPORTEXPORT_VERSION', '1.6.2');
+define('U3A_IMPORTEXPORT_VERSION', '1.6.3');
 
 if (!is_admin()) return; // Plugin only relevant on admin pages.
 
 // Check SiteWorks core plugin is active (needed for some definitions)
+// Check retained for WordPress installations before 6.5 that do not support "Requires Plugins"
+require_once(ABSPATH.'wp-admin/includes/plugin.php');
 if (!is_plugin_active('u3a-siteworks-core/u3a-siteworks-core.php')) {
     return;
 }


### PR DESCRIPTION
Fixes bug reported to sysadmin.  See screenshot.
Also tested against 6.7 RC-1 and added "Requires Plugins" header.
![Screenshot from 2024-10-27 09-24-09](https://github.com/user-attachments/assets/c89114e9-6885-47ed-8385-21f950d0e39f)
