### PR TITLE
1143

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Bug 1143: Import/Export plugin doesn't show groups with 'Unspecified' days when sorted.
 = 1.7.0 =
 * Tested with WordPress 6.8
 * Code refactored to access plugin update service via configuration plugin

--- a/u3a-import.php
+++ b/u3a-import.php
@@ -108,7 +108,7 @@ function u3a_csv_import_groups()
     }
 
     $day_list          = array(
-        '' => '',
+        0  => '',
         1  => 'Monday',
         2  => 'Tuesday',
         3  => 'Wednesday',


### PR DESCRIPTION
The core expects values 0-7 being unset, mon, tues etc. The code checks for 0, or for a missing value. It does not check  for a present value which is an empty string.  The import module accepts an empty string, but does not convert it to a '0'.

Test CSV:

Name,Status,Category,Day
NoDay,Active,History,

